### PR TITLE
Buildguide improvments

### DIFF
--- a/docs/buildguide_3DP.md
+++ b/docs/buildguide_3DP.md
@@ -15,7 +15,7 @@
 | OLED module   | 02 | SSD1306 128x64 pixel OLED Displays |
 | reset button  | 02 | Alps SKRTLAE010 |
 | TRRS jack     | 02 | MJ-4PP-9 or PJ320A |
-| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/serial_driver.md#usart-half-duplex)|
+| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex)|
 | EC11 encoder  | 02 | You can use any EC11 encoder, but it will look better if you use a short one, like the EC11N1524402 |
 | encoder knob  | 02 | The design works best with a 2,2cm encoder knob. I'd recommend kilo international knobs with a number starting with 90. You could also use the [knob](/knob/) I designed for the KLOR, based on the kilo knob. 
 | USB cable     | 01 | For connecting the keyboard to your PC |

--- a/docs/buildguide_3DP.md
+++ b/docs/buildguide_3DP.md
@@ -12,7 +12,7 @@
 | switch socket | 42 | 40 sockets for Konrad / 38 sockets for Yubitsume / 36 sockets for Saegewerk |
 | diodes 1N4148W| 44 | These are surface mount diodes in SOD123 package. 42 for Konrad / 40 for Yubitsume / 38 for Saegewerk |
 | 1u MX keycaps | 42 | 40 keycaps for Konrad / 38 keycaps for Yubitsume / 36 keycaps for Saegewerk |
-| OLED module   | 02 | SSD1306 128x64 pixel OLED Displays |
+| OLED module   | 02 | SSD1306 128x64 pixel I2C OLED Displays with 4 pins |
 | reset button  | 02 | Alps SKRTLAE010 |
 | TRRS jack     | 02 | MJ-4PP-9 or PJ320A |
 | TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex) if your MCU has an ARM chip. Otherwise, if your MCU based on an AVR chip just like Arduino ProMicro, you must use TRRS cable |

--- a/docs/buildguide_3DP.md
+++ b/docs/buildguide_3DP.md
@@ -15,7 +15,7 @@
 | OLED module   | 02 | SSD1306 128x64 pixel OLED Displays |
 | reset button  | 02 | Alps SKRTLAE010 |
 | TRRS jack     | 02 | MJ-4PP-9 or PJ320A |
-| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex)|
+| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex) if your MCU has an ARM chip. Otherwise, if your MCU based on an AVR chip just like Arduino ProMicro, you must use TRRS cable |
 | EC11 encoder  | 02 | You can use any EC11 encoder, but it will look better if you use a short one, like the EC11N1524402 |
 | encoder knob  | 02 | The design works best with a 2,2cm encoder knob. I'd recommend kilo international knobs with a number starting with 90. You could also use the [knob](/knob/) I designed for the KLOR, based on the kilo knob. 
 | USB cable     | 01 | For connecting the keyboard to your PC |

--- a/docs/buildguide_acrylic.md
+++ b/docs/buildguide_acrylic.md
@@ -15,7 +15,7 @@
 | OLED module   | 02 | SSD1306 128x64 pixel OLED Displays |
 | reset button  | 02 | Alps SKRTLAE010 |
 | TRRS jack     | 02 | MJ-4PP-9 or PJ320A |
-| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/serial_driver.md#usart-half-duplex)|
+| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex)|
 | EC11 encoder  | 02 | You can use any EC11 encoder, but it will look better if you use a short one, like the EC11N1524402 |
 | encoder knob  | 02 | The design works best with a 2,2cm encoder knob. I'd recommend kilo international knobs with a number starting with 90. You could also use the [knob](/knob/) I designed for the KLOR, based on the kilo knob. 
 | USB cable     | 01 | For connecting the keyboard to your PC |

--- a/docs/buildguide_acrylic.md
+++ b/docs/buildguide_acrylic.md
@@ -12,7 +12,7 @@
 | switch socket | 42 | 40 sockets for Konrad / 38 sockets for Yubitsume / 36 sockets for Saegewerk |
 | diodes 1N4148W| 44 | These are surface mount diodes in SOD123 package. 42 for Konrad / 40 for Yubitsume / 38 for Saegewerk |
 | 1u MX keycaps | 42 | 40 keycaps for Konrad / 38 keycaps for Yubitsume / 36 keycaps for Saegewerk |
-| OLED module   | 02 | SSD1306 128x64 pixel OLED Displays |
+| OLED module   | 02 | SSD1306 128x64 pixel I2C OLED Displays with 4 pins |
 | reset button  | 02 | Alps SKRTLAE010 |
 | TRRS jack     | 02 | MJ-4PP-9 or PJ320A |
 | TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex) if your MCU has an ARM chip. Otherwise, if your MCU based on an AVR chip just like Arduino ProMicro, you must use TRRS cable |

--- a/docs/buildguide_acrylic.md
+++ b/docs/buildguide_acrylic.md
@@ -15,7 +15,7 @@
 | OLED module   | 02 | SSD1306 128x64 pixel OLED Displays |
 | reset button  | 02 | Alps SKRTLAE010 |
 | TRRS jack     | 02 | MJ-4PP-9 or PJ320A |
-| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex)|
+| TRRS cable    | 01 | Alternatively, you can use a TRS cable for [half-duplex](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#usart-half-duplex) if your MCU has an ARM chip. Otherwise, if your MCU based on an AVR chip just like Arduino ProMicro, you must use TRRS cable |
 | EC11 encoder  | 02 | You can use any EC11 encoder, but it will look better if you use a short one, like the EC11N1524402 |
 | encoder knob  | 02 | The design works best with a 2,2cm encoder knob. I'd recommend kilo international knobs with a number starting with 90. You could also use the [knob](/knob/) I designed for the KLOR, based on the kilo knob. 
 | USB cable     | 01 | For connecting the keyboard to your PC |

--- a/docs/buildguide_acrylic_ble.md
+++ b/docs/buildguide_acrylic_ble.md
@@ -12,7 +12,7 @@
 | switch socket | 42 | 40 sockets for Konrad / 38 sockets for Yubitsume / 36 sockets for Saegewerk |
 | diodes 1N4148W| 44 | These are surface mount diodes in SOD123 package. 42 for Konrad / 40 for Yubitsume / 38 for Saegewerk |
 | 1u MX keycaps | 42 | 40 keycaps for Konrad / 38 keycaps for Yubitsume / 36 keycaps for Saegewerk |
-| OLED module   | 02 | SSD1306 128x64 pixel OLED Displays |
+| OLED module   | 02 | SSD1306 128x64 pixel I2C OLED Displays with 4 pins |
 | reset button  | 02 | Alps SKRTLAE010 |
 | power switch  | 02 | MSK12C02 |
 | EC11 encoder  | 02 | You can use any EC11 encoder, but it will look better if you use a short one, like the EC11N1524402 |


### PR DESCRIPTION
### - Fixed broken link to qmk docs

### - Improve clarification on TRRS cable remark
[According to docs](https://github.com/qmk/qmk_firmware/blob/master/docs/drivers/serial.md#serial-driver) QMK support half-duplex on only ARM chips.

### - Improve clarification on OLED display remark
